### PR TITLE
Fixed gradle configuration 'compile' deprecation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.koushikdutta.async:androidasync:2.1.6'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.koushikdutta.async:androidasync:2.1.6'
 }


### PR DESCRIPTION
Fixed gradle compile deprecation warning as in https://github.com/tradle/react-native-udp/pull/88#issue-298965227.
> 
> ## Intent
> 
> This fixes a breaking API change with the Android Gradle plugin, which was deprecated as of version 3.0.0 and later made obsolete.
> ## Changes
> 
> When adding Gradle dependencies, the `compile` command has been removed and replaced with `implementation`/`api`.
> ## More information
> 
>     * Gradle support docs: https://docs.gradle.org/5.4.1/userguide/java_library_plugin.html#sec:java_library_separation
> 
>     * Android deprecation doc: https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations
