### PR TITLE
Fix the global.process issue in TcpSocket.js while preserving debugging

### DIFF
--- a/TcpSocket.js
+++ b/TcpSocket.js
@@ -8,7 +8,10 @@
 
 'use strict';
 
-global.process = global.process || require('process'); // needed to make stream-browserify happy
+if(!(global.process && global.process.nextTick)){
+  global.process = require('process'); // needed to make stream-browserify happy
+}
+
 var Buffer = global.Buffer = global.Buffer || require('buffer').Buffer;
 
 var util = require('util');


### PR DESCRIPTION
Fix the global.process issue in TcpSocket.js while preserving ability to debug with Chrome/vscode.
Overwrites global.process in TcpSocket.js only when one of the following is true:

global.process does not exist
global.process does exist and global.process.nextTick does not exist.

Port of https://github.com/PeelTechnologies/react-native-tcp/pull/89