### PR TITLE
fix: autolinking when using Xcode 12

### DIFF
--- a/TcpSockets.podspec
+++ b/TcpSockets.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
 
   s.preserve_paths = 'README.md', 'package.json', '**/*.js'
   s.source_files   = 'ios/**/*.{h,m}'
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'CocoaAsyncSocket'
 
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on React-Core directly instead of React. This change requires React Native 0.60.2 or newer. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116