### PR TITLE
(fix) remove CocoaAsyncSocket deps

### DIFF
--- a/TcpSockets.podspec
+++ b/TcpSockets.podspec
@@ -19,6 +19,5 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'README.md', 'package.json', '**/*.js'
   s.source_files   = 'ios/**/*.{h,m}'
   s.dependency 'React'
-  s.dependency 'CocoaAsyncSocket'
 
 end


### PR DESCRIPTION
Fix the following issue:

libCocoaAsyncSocket.a(GCDAsyncSocket.o)
    /Users/xxx/Library/Developer/Xcode/DerivedData/VolatilesApp-xsdfdsfdsfdsef3qr42rewf/Build/Products/Debug-iphoneos/TcpSockets/libTcpSockets.a(GCDAsyncSocket.o)
ld: 79 duplicate symbols for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)